### PR TITLE
IMX8M: fix 4GB LPDDR4 label

### DIFF
--- a/drivers/ddr/imx/imx8m/Kconfig
+++ b/drivers/ddr/imx/imx8m/Kconfig
@@ -12,7 +12,7 @@ config IMX8M_2GB_LPDDR4
 	bool "imx8m 2GB LPDDR4"
 
 config IMX8M_4GB_LPDDR4
-	bool "imx8m 2GB LPDDR4"
+	bool "imx8m 4GB LPDDR4"
 
 config IMX8M_LPDDR4
 	bool "imx8m lpddr4"


### PR DESCRIPTION
The config option for IMX8M 4GB ddr was wrongly labeled
